### PR TITLE
qtmux: for Apple ProRes, allow overriding pixel bit depth, e.g. when exporting an opaque image, yet with alpha.

### DIFF
--- a/gst/isomp4/gstqtmux.c
+++ b/gst/isomp4/gstqtmux.c
@@ -6215,7 +6215,7 @@ gst_qt_mux_video_sink_set_caps (GstQTMuxPad * qtpad, GstCaps * caps)
     mp4v->horizontal_resolution = 72 << 16;
     mp4v->vertical_resolution = 72 << 16;
     mp4v->depth = (entry.fourcc == FOURCC_ap4h
-        || entry.fourcc == FOURCC_ap4x) ? 32 : 24;
+        || entry.fourcc == FOURCC_ap4x) ? (depth > 0 ? depth : 32) : 24;
 
     /* Set compressor name, required by some software */
     switch (entry.fourcc) {


### PR DESCRIPTION
Apple ProRes certification requires that, when a ProRes-writing application knows that the entire frame is opaque, the application writes only RGB without alpha even when the clips is RGBA. So this tiny change allows the app to override pixel depth when writing ProRes.